### PR TITLE
Rework command data structures, scoreboard, data

### DIFF
--- a/examples/tick-and-load/src/tick_load_pack.py
+++ b/examples/tick-and-load/src/tick_load_pack.py
@@ -1,10 +1,12 @@
 from mcpy import Datapack
 from mcpy.cmd import *
 
+def run():
+    print('hello!')
 
+    
 if __name__ == "__main__":
     pack = Datapack()
-
     with pack.namespace("dt.example"):
         # define our on_load function
         with pack.mcfunction("on_load"):
@@ -23,23 +25,24 @@ if __name__ == "__main__":
 
         # now add our tick function
         with pack.mcfunction("on_tick"):
-            two_score = Player('$two', 'dt.example')
-            five_score = Player('$five', 'dt.example')
-            mod_five_score = Player('$dt.mod5', 'dt.example')
-            tmp_score = Player('$dt.tmp', 'dt.example')
-            ticker_score = Player('$dt.ticker', 'dt.example')
             def write_cmds():
-                yield scoreboard.players().set(two_score, 2)
-                yield scoreboard.players().set(five_score, 5)
-                yield scoreboard.players().reset(mod_five_score)
-                yield scoreboard.players().operation(tmp_score).assign(ticker_score)
-                yield scoreboard.players().operation(tmp_score).mod(five_score)
+                two_score = Player('$two', 'dt.example')
+                five_score = Player('$five', 'dt.example')
+                mod_five_score = Player('$dt.mod5', 'dt.example')
+                tmp_score = Player('$dt.tmp', 'dt.example')
+                ticker_score = Player('$dt.ticker', 'dt.example')
+            
+                yield two_score.set(2)
+                yield five_score.set(5)
+                yield mod_five_score.reset()
+                yield tmp_score.assign(ticker_score)
+                yield tmp_score.mod(five_score)
                 yield f"""\
                 execute if score $dt.tmp dt.example matches 0 run scoreboard players set $dt.mod5 dt.example 1
-                execute if score {mod_five_score} matches 1 run scoreboard players operation $dt.tmp dt.example = $dt.ticker dt.example
-                execute if score {mod_five_score} matches 1 run scoreboard players operation $dt.tmp dt.example %= $two dt.example
-                execute if score {mod_five_score} matches 1 if score $dt.tmp dt.example matches 0 run say Tick!
-                execute if score {mod_five_score} matches 1 unless score $dt.tmp dt.example matches 0 run say Tock!
+                execute if score $dt.mod5 dt.example matches 1 run scoreboard players operation $dt.tmp dt.example = $dt.ticker dt.example
+                execute if score $dt.mod5 dt.example matches 1 run scoreboard players operation $dt.tmp dt.example %= $two dt.example
+                execute if score $dt.mod5 dt.example matches 1 if score $dt.tmp dt.example matches 0 run say Tick!
+                execute if score $dt.mod5 dt.example matches 1 unless score $dt.tmp dt.example matches 0 run say Tock!
                 scoreboard players add $dt.ticker dt.example 1
                 """
             pack.write(write_cmds())

--- a/src/mcpy/cmd/__init__.py
+++ b/src/mcpy/cmd/__init__.py
@@ -1,5 +1,2 @@
 from .data import *
 from .scoreboard import *
-
-data = DataCmd()
-scoreboard = ScoreboardCmd()

--- a/src/mcpy/cmd/common.py
+++ b/src/mcpy/cmd/common.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass, asdict
+from .util import tokens_to_str
+@dataclass
+class Player:
+    name: str
+    objective: str
+
+
+# @dataclass
+# class __Target:
+#     target: str
+#     target_path: str = None
+
+@dataclass
+class Storage:
+    target: str
+    target_path: str = None
+
+
+@dataclass
+class Entity:
+    target: str
+    target_path: str = None
+
+
+@dataclass
+class Pos:
+    x: str
+    y: str
+    z: str
+
+    def __str__(self) -> str:
+        return tokens_to_str(self.x,self.y,self.z)
+
+@dataclass
+class Block:
+    pos: Pos | str
+    target_path: str = None

--- a/src/mcpy/cmd/data.py
+++ b/src/mcpy/cmd/data.py
@@ -1,95 +1,108 @@
 from dataclasses import dataclass
 import functools
-from .util import (
-    RootCmd,
-    SubCmd,
-    BaseCmd,
-    EndCmd,
-)
+from .util import RootCmd, SubCmd, BaseCmd, EndCmd, tokens_to_str
+from .common import Pos
 
-
-@dataclass
-class Storage:
-    target: str
-
-    def __str__(self) -> str:
-        return f"storage {self.target}"
-
-
-@dataclass
-class Entity:
-    target: str
-
-    def __str__(self) -> str:
-        return f"entity {self.target}"
-
-
-@dataclass
-class Pos:
-    x: str
-    y: str
-    z: str
-
-    def __str__(self) -> str:
-        return f"{self.x} {self.y} {self.z}"
-
-
-@dataclass
-class Block:
-    pos: Pos | str
-
-    def __str__(self) -> str:
-        return f"block {self.pos}"
-
-
-class DataCmd(RootCmd):
+class Data(RootCmd):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__("data", *args, *kwargs)
+
+    class Target(SubCmd):
+        def __init__(
+            self,
+            # parent: BaseCmd | str,
+            target_type: str,
+            target: str,
+            target_path: str = None,
+        ) -> None:
+            super().__init__(
+                Data(),
+                "",
+                template_args={
+                    "target": target,
+                    "target_type": target_type,
+                    "target_path": target_path,
+                },
+            )
+
+        def get(
+            self,
+            scale: int = None,
+        ) -> str:
+            return EndCmd(
+                self,
+                ["get $target_type $target", "$target_path", "$scale"],
+                {"scale": scale},
+            )
+
+        def merge(self, nbt: str) -> str:
+            return EndCmd(
+                self,
+                ["merge $target_type $target", "$nbt"],
+                {"nbt": nbt},
+            )
+
+        def remove(
+            self,
+        ) -> str:
+            return EndCmd(
+                self,
+                ["remove $target_type $target", "$target_path"],
+            )
+
+        def modify(self):
+            return Data.ModifyCmd(self)
+    
+    class Entity(Target):
+        def __init__(self, target: str, target_path: str = None) -> None:
+            super().__init__("entity", target, target_path)
+
+    class Block(Target):
+        def __init__(self, target: Pos | str, target_path: str = None) -> None:
+            super().__init__("block", str(target), target_path)
+
+    class Storage(Target):
+        def __init__(self, target: str, target_path: str = None) -> None:
+            super().__init__("storage", target, target_path)
 
     class ModifyCmd(SubCmd):
         def __init__(
             self,
             parent: BaseCmd | str,
-            target: Block | Entity | Storage | str,
-            target_path: str = None,
-            *args,
-            **kwargs,
         ) -> None:
             super().__init__(
                 parent,
-                ["modify $target", "$target_path"],
-                template_args={"target": target, "target_path": target_path},
-                *args,
-                **kwargs,
+                ["modify $target_type $target", "$target_path"],
             )
 
         def __action_from(
             self,
             action: str,
-            source: Block | Entity | Storage | str,
-            source_path: str = None,
+            source: any, #"DataCmd.Block" | "DataCmd.Entity" | "DataCmd.Storage"
         ):
             return EndCmd(
                 self,
-                ["$action from $source", "$source_path"],
-                {"action": action, "source": source, "source_path": source_path},
+                ["$action from $source_type $source", "$source_path"],
+                source._template_args | {"action": action},
             )
 
         def __action_string(
             self,
             action: str,
-            source: Block | Entity | Storage | str,
-            source_path: str = None,
+            source: any, #"DataCmd.Block" | "DataCmd.Entity" | "DataCmd.Storage" | str,
             start: int = None,
             end: int = None,
         ):
             return EndCmd(
                 self,
-                ["$action from string $source", "$source_path", "$start $end"],
-                {
+                [
+                    "$action from string $source_type $source",
+                    "$source_path",
+                    "$start $end",
+                ],
+                source._template_args
+                | {
                     "action": action,
-                    "source": source,
-                    "source_path": source_path,
                     "start": start,
                     "end": end,
                 },
@@ -121,38 +134,12 @@ class DataCmd(RootCmd):
         set_string = functools.partialmethod(__action_string, "set")
         set_value = functools.partialmethod(__action_value, "set")
 
-    def get(
-        self,
-        target: Block | Entity | Storage | str,
-        target_path: str = None,
-        scale: int = None,
-    ) -> str:
-        return EndCmd(
-            self,
-            ["data get $target", "$target_path", "$scale"],
-            {"target": target, "target_path": target_path, "scale": scale},
-        )
 
-    def merge(
-        self, target: Block | Entity | Storage | str, nbt: str, target_path: str = None
-    ) -> str:
-        return EndCmd(
-            self,
-            ["data merge $target", "$target_path", "$nbt"],
-            {"target": target, "target_path": target_path, "nbt": nbt},
-        )
+class Entity(Data.Entity):
+    pass
 
-    def remove(
-        self, target: Block | Entity | Storage | str, target_path: str = None
-    ) -> str:
-        return EndCmd(
-            self,
-            ["data remove $target", "$target_path"],
-            {
-                "target": target,
-                "target_path": target_path,
-            },
-        )
+class Storage(Data.Storage):
+    pass
 
-    def modify(self, target: Block | Entity | Storage | str, target_path: str = None):
-        return DataCmd.ModifyCmd(self, target, target_path=target_path)
+class Block(Data.Block):
+    pass

--- a/src/mcpy/cmd/scoreboard.py
+++ b/src/mcpy/cmd/scoreboard.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from .util import (
     RootCmd,
     SubCmd,
@@ -6,20 +5,12 @@ from .util import (
     EndCmd,
 )
 
-@dataclass
-class Player:
-    name: str
-    objective: str
 
-    def __str__(self) -> str:
-        return f"{self.name} {self.objective}"
-
-
-class ScoreboardCmd(RootCmd):
+class Scoreboard(RootCmd):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__("scoreboard", *args, **kwargs)
 
-    class ObjectivesCmd(SubCmd):
+    class Objective(SubCmd):
         def __init__(self, parent: BaseCmd | str, *args, **kwargs) -> None:
             super().__init__(parent, "objectives", *args, **kwargs)
 
@@ -37,84 +28,78 @@ class ScoreboardCmd(RootCmd):
                 },
             )
 
-    def objectives(self):
-        return ScoreboardCmd.ObjectivesCmd()
+    def objectives(self, *args, **kwargs):
+        return Scoreboard.Objective(self, *args, **kwargs)
 
-    class PlayersCmd(SubCmd):
-        def __init__(self, parent: BaseCmd | str, *args, **kwargs) -> None:
-            super().__init__(parent, "players", *args, **kwargs)
-
-        def set(self, player: Player, score: int):
-            return EndCmd(
-                self,
-                "set $player $score",
-                {
-                    "player": player,
-                    "score": score,
-                },
+    class Player(SubCmd):
+        def __init__(self, name: str, objective: str, *args, **kwargs) -> None:
+            super().__init__(
+                Scoreboard(),
+                "players",
+                template_args={"name": name, "objective": objective},
+                *args,
+                **kwargs,
             )
 
-        def reset(self, player: Player):
+        def set(self, score: int):
             return EndCmd(
-                self,
-                "reset $player",
-                {
-                    "player": player,
-                },
+                self, "set $name $objective $score", template_args={"score": score}
             )
 
-        class OperationCmd(SubCmd):
-            def __init__(
-                self, parent: BaseCmd | str, target_player: Player, *args, **kwargs
-            ) -> None:
+        def reset(self):
+            return EndCmd(self, "reset $name $objective")
+
+        class Operation(SubCmd):
+            def __init__(self, parent: BaseCmd | str, *args, **kwargs) -> None:
                 super().__init__(
                     parent,
-                    "operation $target_player",
-                    template_args={"target_player": target_player},
+                    "operation $name $objective",
                     *args,
                     **kwargs,
                 )
 
-            def __operation(self, operation: str, source_player: Player):
+            def __operation(self, operation: str, source_player: "Scoreboard.Player"):
                 return EndCmd(
                     self,
-                    "$operation $source_player",
-                    {
-                        "operation": operation,
-                        "source_player": source_player,
-                    },
+                    "$operation $name $objective",
+                    source_player._template_args | {"operation": operation},
                 )
 
-            def assign(self, source_player: Player):
+            def assign(self, source_player: "Scoreboard.Player"):
                 return self.__operation("=", source_player)
 
-            def add(self, source_player: Player):
+            def add(self, source_player: "Scoreboard.Player"):
                 return self.__operation("+=", source_player)
 
-            def subtract(self, source_player: Player):
+            def subtract(self, source_player: "Scoreboard.Player"):
                 return self.__operation("-=", source_player)
 
-            def multiply(self, source_player: Player):
-                return self.__operation("+=", source_player)
+            def multiply(self, source_player: "Scoreboard.Player"):
+                return self.__operation("*=", source_player)
 
-            def divide(self, source_player: Player):
+            def divide(self, source_player: "Scoreboard.Player"):
                 return self.__operation("/=", source_player)
 
-            def mod(self, source_player: Player):
+            def mod(self, source_player: "Scoreboard.Player"):
                 return self.__operation("%=", source_player)
 
-            def swap(self, source_player: Player):
+            def swap(self, source_player: "Scoreboard.Player"):
                 return self.__operation("><", source_player)
 
-            def min(self, source_player: Player):
+            def min(self, source_player: "Scoreboard.Player"):
                 return self.__operation("<", source_player)
 
-            def max(self, source_player: Player):
+            def max(self, source_player: "Scoreboard.Player"):
                 return self.__operation(">", source_player)
 
-        def operation(self, target_player: Player):
-            return ScoreboardCmd.PlayersCmd.OperationCmd(self, target_player)
+        def operation(self):
+            return Scoreboard.Player.Operation(self)
 
-    def players(self):
-        return ScoreboardCmd.PlayersCmd(self)
+    def players(self, name: str, objective: str):
+        return Scoreboard.Player(name, objective)
+
+
+# Re define at top-level
+class Player(Scoreboard.Player):
+    pass
 

--- a/src/mcpy/cmd/util.py
+++ b/src/mcpy/cmd/util.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from string import Template
 import re
 
+
 def tokens_to_str(*tokens):
     tokens = filter(bool, tokens)
     tokens = map(lambda t: str(t), tokens)
@@ -9,16 +10,20 @@ def tokens_to_str(*tokens):
 
     return " ".join(tokens) if tokens else ""
 
+def run_partial_templates(template_strings: list[str], template_args: dict) -> list[str]:
+    template_args = {k: ("" if v is None else v) for k, v in template_args.items()}
+    return [Template(t).safe_substitute(template_args) for t in template_strings]
 
-def run_templates_to_str(template_str_or_list: str | list[str], template_args: dict):
-    template_str_list = (
-        template_str_or_list
-        if isinstance(template_str_or_list, list)
-        else [template_str_or_list]
-    )
-    template_args = {k: ('' if v is None else v) for k,v in template_args.items()}
-    cmd_tokens = [Template(t).substitute(template_args) for t in template_str_list]
-    return tokens_to_str(*cmd_tokens)
+# def run_templates_to_str(template_str_or_list: str | list[str], template_args: dict):
+#     template_str_list = (
+#         [template_str_or_list]
+#         if isinstance(template_str_or_list, str)
+#         else list(template_str_or_list)
+#     )
+
+#     template_args = {k: ("" if v is None else v) for k, v in template_args.items()}
+#     cmd_tokens = [Template(t).substitute(template_args) for t in template_str_list]
+#     return tokens_to_str(*cmd_tokens)
 
 
 class BaseCmd(ABC):
@@ -29,20 +34,17 @@ class BaseCmd(ABC):
         template_args=None,
     ) -> None:
         self.__parent = parent
-        self.__template_str_list = (
-            template_str_or_list
-            if isinstance(template_str_or_list, list)
-            else [template_str_or_list]
-        )
-        self.__template_args = template_args if template_args else {}
+        self.__template_strings = [template_str_or_list] if isinstance(template_str_or_list, str) else list(template_str_or_list)
+        self._template_args = template_args if template_args else {}
+
+    
+    def _convert(self, *suffix_templates: str) -> str:
+        template_strings = [*self.__template_strings, *suffix_templates]
+        partials = run_partial_templates(template_strings, self._template_args)
+        return self.__parent._convert(*partials) if self.__parent else partials
 
     def __str__(self) -> str:
         raise ValueError("Unable to convert to string")
-
-    def _convert(self, *suffix_tokens: str) -> str:
-        prefix = self.__parent._convert() if self.__parent else ""
-        cmd = run_templates_to_str(self.__template_str_list, self.__template_args)
-        return tokens_to_str(prefix, cmd, *suffix_tokens)
 
 
 class RootCmd(BaseCmd):
@@ -54,6 +56,7 @@ class SubCmd(BaseCmd, ABC):
     def __init__(self, parent: BaseCmd | str, *args, **kwargs) -> None:
         super().__init__(parent, *args, **kwargs)
 
+
 class EndCmd(BaseCmd):
     def __str__(self) -> str:
-        return self._convert()
+        return tokens_to_str(*self._convert())

--- a/tests/mcpy/test_cmds.py
+++ b/tests/mcpy/test_cmds.py
@@ -1,0 +1,122 @@
+import mcpy.cmd.scoreboard as scoreboard
+import mcpy.cmd.data as data
+
+def __assert_cmds(expected_str: str, cmd: any):
+    assert expected_str == str(cmd)
+
+
+def test_scoreboard():
+    # objectives
+    # list
+    __assert_cmds(
+        "scoreboard objectives list", scoreboard.Scoreboard().objectives().list()
+    )
+
+    # add
+    __assert_cmds(
+        "scoreboard objectives add test.obj dummy",
+        scoreboard.Scoreboard().objectives().add("test.obj", "dummy"),
+    )
+    __assert_cmds(
+        "scoreboard objectives add test.obj dummy TEST_OBJ",
+        scoreboard.Scoreboard()
+        .objectives()
+        .add("test.obj", "dummy", display_name="TEST_OBJ"),
+    )
+    # players
+    # set
+    expected = "scoreboard players set test.player test.obj 123"
+    cmd = scoreboard.Player("test.player", "test.obj").set(123)
+    assert expected == str(cmd)
+    # set
+    expected = "scoreboard players reset test.player test.obj"
+    cmd = scoreboard.Player("test.player", "test.obj").reset()
+    assert expected == str(cmd)
+
+    # operation =
+    expected = (
+        "scoreboard players operation test.player test.obj = test.player2 test.obj2"
+    )
+    cmd = (
+        scoreboard.Player("test.player", "test.obj")
+        .operation()
+        .assign(scoreboard.Player("test.player2", "test.obj2"))
+    )
+    assert expected == str(cmd)
+    # operation +=
+    expected = (
+        "scoreboard players operation test.player test.obj += test.player2 test.obj2"
+    )
+    cmd = (
+        scoreboard.Player("test.player", "test.obj")
+        .operation()
+        .add(scoreboard.Player("test.player2", "test.obj2"))
+    )
+    assert expected == str(cmd)
+
+    # operation -=
+    expected = (
+        "scoreboard players operation test.player test.obj -= test.player2 test.obj2"
+    )
+    cmd = (
+        scoreboard.Player("test.player", "test.obj")
+        .operation()
+        .subtract(scoreboard.Player("test.player2", "test.obj2"))
+    )
+    assert expected == str(cmd)
+    # operation *=
+    expected = (
+        "scoreboard players operation test.player test.obj *= test.player2 test.obj2"
+    )
+    cmd = (
+        scoreboard.Player("test.player", "test.obj")
+        .operation()
+        .multiply(scoreboard.Player("test.player2", "test.obj2"))
+    )
+    assert expected == str(cmd)
+
+    # operation /=
+    __assert_cmds(
+        "scoreboard players operation test.player test.obj /= test.player2 test.obj2",
+        scoreboard.Player("test.player", "test.obj")
+        .operation()
+        .divide(scoreboard.Player("test.player2", "test.obj2")),
+    )
+
+    # operation %=
+    __assert_cmds(
+        "scoreboard players operation test.player test.obj %= test.player2 test.obj2",
+        scoreboard.Player("test.player", "test.obj")
+        .operation()
+        .mod(scoreboard.Player("test.player2", "test.obj2")),
+    )
+
+    # operation <
+    __assert_cmds(
+        "scoreboard players operation test.player test.obj < test.player2 test.obj2",
+        scoreboard.Player("test.player", "test.obj")
+        .operation()
+        .min(scoreboard.Player("test.player2", "test.obj2")),
+    )
+
+    # operation >
+    __assert_cmds(
+        "scoreboard players operation test.player test.obj > test.player2 test.obj2",
+        scoreboard.Player("test.player", "test.obj")
+        .operation()
+        .max(scoreboard.Player("test.player2", "test.obj2")),
+    )
+    # operation ><
+    __assert_cmds(
+        "scoreboard players operation test.player test.obj >< test.player2 test.obj2",
+        scoreboard.Player("test.player", "test.obj")
+        .operation()
+        .swap(scoreboard.Player("test.player2", "test.obj2")),
+    )
+
+def test_data():
+    # storage get,remove,merge
+    __assert_cmds('data get storage test.example foopath', data.Storage('test.example','foopath').get())
+    __assert_cmds('data remove storage test.example foopath', data.Storage('test.example','foopath').remove())
+    __assert_cmds('data merge storage test.example {foo:1b}', data.Storage('test.example','foopath').merge("{foo:1b}"))
+    # modify


### PR DESCRIPTION
Rework command data structures to be "target" oriented to reduce verbosity. For example,
```python
Storage('foo').get()
# instead of
Data().get(Storage('foo'))
```