### PR TITLE
Improve mcpy cli api

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,20 @@
 A library for writing Minecraft datapacks using the Python language.
 
 ```python
-# my-pack/src/pack.py
-def run():
-    pack = Datapack()
-    def builder(ctx: Context):
-        with namespace(ctx, "mypack"):
-            with mcfunction(ctx, "say_hello"):
-                # in mcfunction context
-                for i in range(3):
-                    yield f"say {i+1}.."
-                yield "say Hello!"
-    pack.build(builder)
+from mcpy import *
 
+@datapack
+def simple_pack():
+    with namespace(ctx, "mypack"):
+        with mcfunction(ctx, "say_hello"):
+            # in mcfunction context
+            for i in range(3):
+                yield f"say {i+1}.."
+            yield "say Hello!"
 ```
 
 ```bash
-> python -m mcpy pack:run
+> python -m mcpy
 # Outputs the data dir:
 # my-pack
 # ├── data
@@ -77,16 +75,16 @@ Disadvantages:
 2. In `src/` create a `.py` file and use the `mcpy` library
 
     ```python
-    # py_pack.py
-    from mcpy import Datapack
+    from mcpy import *
 
-    def run():
-        pack = Datapack()
-        def builder(ctx: Context):
-            with namespace(ctx, 'mypack'):
-                with mcfunction(ctx,'my_func'):
-                    yield 'Hello from my func'
-        pack.build(builder)
+    @datapack
+    def simple_pack():
+        with namespace(ctx, "mypack"):
+            with mcfunction(ctx, "say_hello"):
+                # in mcfunction context
+                for i in range(3):
+                    yield f"say {i+1}.."
+                yield "say Hello!"
     ```
 
 3. Run the script from the `src` or datapack directory to generate the `data` folder with your pack contents.
@@ -132,8 +130,8 @@ with blocks(ctx, 'name'):
 # import using standard python
 from mcpy_recurse import recurse
 ...
-with pack.recurse(ctx, some, args):
-    pack.write('say Over and over')
+with recurse(ctx, some, args):
+    yield 'say Over and over'
 ```
 
 ### Organize Complexity

--- a/examples/simple-datapack/data/dt.simple/functions/api/greeting/hello.mcfunction
+++ b/examples/simple-datapack/data/dt.simple/functions/api/greeting/hello.mcfunction
@@ -1,4 +1,4 @@
 # Built with mcpy (https://github.com/dthigpen/mcpy)
 
 say Hello
-say There!
+say There!!

--- a/examples/simple-datapack/src/pack.py
+++ b/examples/simple-datapack/src/pack.py
@@ -1,12 +1,13 @@
 from mcpy import *
 
 
-def run(ctx: Context):
+@datapack
+def simple_pack(ctx: Context):
     with namespace(ctx, "dt.simple"):
         with dir(ctx, "api/greeting"):
             with mcfunction(ctx, "hello"):
                 yield "say Hello"
-                yield "say There!"
+                yield "say There!!"
 
             # or with multiple commands in one str:
             with mcfunction(ctx, "morning"):

--- a/examples/tick-and-load/data/dt.example/functions/on_load.mcfunction
+++ b/examples/tick-and-load/data/dt.example/functions/on_load.mcfunction
@@ -3,4 +3,4 @@
 scoreboard objectives add dt.example dummy
 scoreboard players reset * dt.example
 scoreboard players set $dt.ticker dt.example 0
-say Loaded Tick-And-Load
+say Loaded Tick-And-Load!!!

--- a/examples/tick-and-load/src/pack.py
+++ b/examples/tick-and-load/src/pack.py
@@ -1,7 +1,8 @@
 from mcpy import *
 from mcpy_cmd import *
 
-def run(ctx: Context):
+@datapack
+def tick_and_load(ctx: Context):
     pack_namespace = "dt.example"
     pack_objective = Scoreboard.Objective(pack_namespace)
     with namespace(ctx, "dt.example"):
@@ -11,7 +12,7 @@ def run(ctx: Context):
             yield Scoreboard.Player("*", pack_objective).reset()
             ticker_score = Scoreboard.Player("$dt.ticker", "dt.example")
             yield ticker_score.set(0)
-            yield "say Loaded Tick-And-Load"
+            yield "say Loaded Tick-And-Load!!!"
         # add it to the minecraft load tag
         with namespace(ctx, "minecraft"):
             with functions(ctx, "load"):
@@ -43,8 +44,3 @@ def run(ctx: Context):
         with namespace(ctx, "minecraft"):
             with functions(ctx, "tick"):
                 yield {"values": ["dt.example:on_tick"]}
-
-
-
-if __name__ == "__main__":
-    run()

--- a/src/mcpy/__init__.py
+++ b/src/mcpy/__init__.py
@@ -1,2 +1,3 @@
 from .context import *
 from .util import *
+from .mcpy import datapack

--- a/src/mcpy/mcpy.py
+++ b/src/mcpy/mcpy.py
@@ -1,40 +1,112 @@
 import argparse
 import importlib
 from typing import Callable
+from types import ModuleType
 from pathlib import Path
 from timeit import default_timer as timer
 import traceback
 from datetime import timedelta
 from .context import Context, write
-
+import functools
+import json
 from watchfiles import watch
 
-def module_attr(module_attr_str: str) -> tuple:
-    # accepts values such as:
-    # path.sub:funct, path/sub:funct, path.sub.funct, etc
-    module_attr_str = module_attr_str.replace('/','.').replace(':','.')
-    if "." not in module_attr_str:
-        raise argparse.ArgumentTypeError(
-            "Bad module run specifier. Use format <module.sub>:<run_function> format"
-        )
-    name, attr = module_attr_str.rsplit(".", 1)
-    return name, attr
+import dpbuild
+
+
+def datapack(func):
+    @functools.wraps(func)
+    def datapack_wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    datapack_wrapper.mcpy_datapack = True
+    return datapack_wrapper
+
+class Datapack:
+    def __init__(self, path: str | Path) -> None:
+        self.path = valid_datapack_path(path)
+
+    def build(self, changed_files: list[Path]) -> None:
+        pass
+
+
+class McpyDatapack(Datapack):
+    def __init__(self, path) -> None:
+        super().__init__(path)
+        valid_mcpy_datapack_path(path)
+        self.module = None
+
+    def get_config(self) -> dict:
+        config_file_name = "mcpy_config.json"
+        config = {"entrypoint": "pack.py"}
+        config_file_path = None
+        if (p := self.path / config_file_name).is_file():
+            config_file_path = p
+        elif (p := self.path / "src" / config_file_name).is_file():
+            config_file_path = p
+        # TODO lastly check inside module folder with glob
+        if config_file_path:
+            with open(config_file_path) as f:
+                config = json.load(f)
+        return config
+
+    def get_module_path(self) -> Path:
+        config = self.get_config()
+        if "entrypoint" in config:
+            pack_file_name = config["entrypoint"]
+            if (p := self.path / pack_file_name).is_file():
+                return p
+            if (p := self.path / "src" / pack_file_name).is_file():
+                return p
+            res = (self.path / "src").glob(f"*/{pack_file_name}")
+            if res:
+                return next(res)
+        raise ValueError("Unable to find entrypoint .py file!")
+
+    def build(self, output_dir=None) -> None:
+        if not output_dir:
+            output_dir = self.path
+        if not self.module:
+            module_path = self.get_module_path()
+            module_name = str(module_path.parent / module_path.stem).replace("/", ".")
+            self.module = importlib.import_module(module_name)
+        else:
+            self.module = importlib.reload(self.module)
+
+        marked_functions = [
+            f
+            for _, f in self.module.__dict__.items()
+            if callable(f) and hasattr(f, "mcpy_datapack") and f.mcpy_datapack is True
+        ]
+        if len(marked_functions) == 0:
+            raise ValueError(
+                "No entrypoint found. Use @mcpy.entrypoint decorator to specify an entrypoint"
+            )
+        if len(marked_functions) > 1:
+            raise ValueError("More than one entrypoint found. Only one is allowed")
+
+        build(marked_functions[0], output_dir)
 
 
 def get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Build mcpy datapacks!")
     parser.add_argument(
-        "entrypoint",
-        type=module_attr,
-        help='"<module>:<attr>" string to call your datapack building function. e.g. for my_pack.py with a run function: my_pack:run',
+        "mcpy_datapack",
+        nargs="?",
+        type=McpyDatapack,
+        default=".",
+        help="mcpy python file",
     )
     parser.add_argument(
         "-w", "--watch", action="store_true", help="watch file changes and rebuild"
     )
+    parser.add_argument(
+        "-o", "--output-dir", type=Path, help="Directory to put compiled datapack"
+    )
     return parser.parse_args()
 
 
-def __get_base_dir(base_dir: Path=None) -> Path:
+def __get_base_dir(base_dir: Path = None) -> Path:
     if base_dir is None:
         cwd = Path.cwd()
         if cwd.joinpath("pack.mcmeta").is_file():
@@ -48,36 +120,67 @@ def __get_base_dir(base_dir: Path=None) -> Path:
     return Path.cwd() if base_dir is None else Path(base_dir)
 
 
-def build(*builder_fns: Callable[[Context],None]):
-        for builder in builder_fns:
-            ctx = Context(__get_base_dir())
-            items = builder(ctx)
-            if items:
-                for item in items:
-                    write(ctx, item)
+def build(builder_fn: Callable[[Context], None], output_dir: Path):
+    ctx = Context(__get_base_dir(output_dir))
+    items = builder_fn(ctx)
+    if items:
+        for item in items:
+            write(ctx, item)
+
+
+def valid_datapack_path(path_str: str) -> Path:
+    path = Path(path_str)
+    if not path.is_dir():
+        raise argparse.ArgumentTypeError(f"Path to datapack does not exist: {path}")
+
+    mc_meta_file = path / "pack.mcmeta"
+    if not mc_meta_file.is_file():
+        raise argparse.ArgumentTypeError(
+            f"Datapack does not have a pack.mcmeta file: {mc_meta_file}"
+        )
+
+    return path
+
+
+def valid_mcpy_datapack_path(path_str: str) -> Path:
+    path = valid_datapack_path(path_str)
+
+    if (
+        path.glob("*.py")
+        or (path / "src").glob("*.py")
+        or (path / "src").glob("*/*.py")
+    ):
+        return path
+    raise argparse.ArgumentTypeError(
+        f"Datapack does not contain a .py file at {path.name}, {path / 'src'} or {path / 'src' / 'module'}"
+    )
+
+
+def output_bundled(output_dir: Path, datapack_paths: list[Path]):
+    print("bundling")
+    if output_dir:
+        dpbuild.run([datapack_paths], output_dir, strict=True)
+
 def main():
     args = get_args()
-    module_name, entrypoint_fn_name = args.entrypoint
-    entrypoint_mod = importlib.import_module(module_name)
-    
-    def timed_build(runner_fn):
-        print("Starting build...")
+    datapack = args.mcpy_datapack
+
+    def timed_build():
+        print(f"Building {datapack.path}")
         start = timer()
-        build(runner_fn)
+        datapack.build(output_dir = args.output_dir)
         end = timer()
         delta = timedelta(seconds=end - start)
         print(f"Build time: {delta}")
-
-    timed_build(getattr(entrypoint_mod, entrypoint_fn_name))
+    
+    timed_build()
+    
     if args.watch:
-        mod_path = Path(entrypoint_mod.__file__)
-        print(f"Watching files in {mod_path.parent}")
+        print(f"Watching files")
         print("Press Ctrl-C to stop at anytime")
-        for changes in watch(mod_path.parent, raise_interrupt=False):
+        for _ in watch(datapack.get_module_path().parent, raise_interrupt=False):
             try:
-                entrypoint_mod = importlib.reload(entrypoint_mod)
-                runner = getattr(entrypoint_mod, entrypoint_fn_name)
-                timed_build(runner)
+                timed_build()
             except KeyboardInterrupt as e:
                 raise e
             except Exception:


### PR DESCRIPTION
No longer need `module_path:run_fn`. Can now just do `py -m mcpy path/to/datapack` or `py -m mcpy` if in the datapack dir.